### PR TITLE
Support Oreo notifications

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,12 +10,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.2.2'
+    }
+}
+
 apply plugin: 'com.android.library'
 
 android {
@@ -16,6 +25,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+}
+
+
+repositories {
+    jcenter()
 }
 
 dependencies {

--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -24,6 +24,7 @@ import com.wix.reactnativenotifications.core.notificationdrawer.NotificationDraw
 import com.wix.reactnativenotifications.core.notifications.ILocalNotification;
 import com.wix.reactnativenotifications.core.notifications.LocalNotification;
 import com.wix.reactnativenotifications.core.notifications.NotificationProps;
+import com.wix.reactnativenotifications.core.notifications.OreoNotifications;
 import com.wix.reactnativenotifications.fcm.FcmTokenService;
 
 import static com.wix.reactnativenotifications.Defs.LOGTAG;
@@ -48,6 +49,7 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
     @Override
     public void initialize() {
         Log.d(LOGTAG, "Native module init");
+        OreoNotifications.initialize(getReactApplicationContext().getApplicationContext());
         final INotificationDrawer notificationsDrawer = NotificationDrawer.get(getReactApplicationContext().getApplicationContext());
         notificationsDrawer.onAppInit();
     }

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notifications/LocalNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notifications/LocalNotification.java
@@ -146,6 +146,8 @@ public class LocalNotification implements ILocalNotification {
             builder.setColor(color);
         }
 
+        OreoNotifications.setChannel(mContext, builder);
+
         final Integer lightsColor = mNotificationProps.getLightsColor();
         final Integer lightsOnMs = mNotificationProps.getLightsOnMs();
         final Integer lightsOffMs = mNotificationProps.getLightsOffMs();

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notifications/OreoNotifications.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notifications/OreoNotifications.java
@@ -1,0 +1,51 @@
+package com.wix.reactnativenotifications.core.notifications;
+
+import android.app.Notification;
+import android.annotation.TargetApi;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+import android.util.Log;
+
+import static com.wix.reactnativenotifications.Defs.LOGTAG;
+
+public class OreoNotifications {
+
+    public static void initialize(Context context) {
+        Log.d(LOGTAG, "OreoNotifications.initialize()");
+
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) return;
+
+        createDefaultChannel(context);
+    }
+
+    private static String getChannelName(Context context) {
+        return getChannelId(context);
+    }
+
+    public static String getChannelId(Context context) {
+        return context.getPackageName() + "_default";
+    }
+
+    public static void setChannel(Context context, Notification.Builder builder) {
+        Log.d(LOGTAG, "OreoNotifications.setChannel()");
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) return;
+
+        builder.setChannelId(getChannelId(context));
+    }
+
+    @TargetApi(26)
+    private static void createDefaultChannel(Context context) {
+        Log.d(LOGTAG, "OreoNotifications.createDefaultChannel()");
+
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        String channelId = getChannelId(context);
+        String channelName = getChannelName(context);
+        NotificationChannel channel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_DEFAULT);
+        channel.setDescription(channelName);
+
+        notificationManager.createNotificationChannel(channel);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-notifications",
-  "version": "1.1.13",
+  "version": "1.2.0",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Android Oreo (API 26) requires notification channels to be created and used with notifications.

This PR creates a default notification channel and uses it when sending local notifications.